### PR TITLE
GliaWidgets: Add to exclude_files GliaWindow that is not used in the SDK

### DIFF
--- a/GliaWidgets/0.5.8/GliaWidgets.podspec
+++ b/GliaWidgets/0.5.8/GliaWidgets.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
     s.swift_version         = '5.3'
   
     s.resources             = ['GliaWidgets/Resources/*.{xcassets}', 'GliaWidgets/Resources/**/*.{strings}', 'GliaWidgets/Resources/Font/*.{ttf}']
+    s.exclude_files         = ['GliaWidgets/Window/**']
     
     s.dependency 'SalemoveSDK', '0.31.0'
     s.dependency 'PureLayout', '~>3.1'


### PR DESCRIPTION
GliaWindow is not used in the SDK and has not been removed from the source folder for some reason (perhaps just by mistake). Due to this, the SDK project gets a compilation error.
The current fix solves the issue in the latest 0.5.8.

GliaWidgets PR: https://github.com/salemove/ios-sdk-widgets/pull/194
This fix updates local podspec and fixes the issue for the next releases.

Issue: https://github.com/salemove/ios-sdk-widgets/issues/191