### PR TITLE
Add `bitrise.yml` to repository

### DIFF
--- a/fastlane/bitrise.yml
+++ b/fastlane/bitrise.yml
@@ -1,0 +1,17 @@
+---
+format_version: '11'
+default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
+project_type: other
+workflows:
+  upload_core_sdk_podspec:
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@6: {}
+    - fastlane@3:
+        inputs:
+        - work_dir: $BITRISE_SOURCE_DIR/fastlane
+        - lane: 'ios upload_podspec version:$BITRISE_GIT_TAG'
+        is_always_run: true
+meta:
+  bitrise.io:
+    stack: osx-xcode-13.4.x


### PR DESCRIPTION
In order to have changes to the `bitrise.yml` go through source
control, the file is added to the repository. This file already has
one workflow, called `upload_core_sdk_podspec`, which generates a
podspec for the Core SDK and creates a PR with it in this repository.

MOB-1504