### PR TITLE
Create a new podspec on Widgets SDK release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,7 @@ platform :ios do
   desc "Creates a PR with the podspec for the Core SDK.\n\n"\
     "Usage:\n"\
     "fastlane ios upload_core_sdk_podspec version:1.0.0\n"
-  lane :upload_podspec do |options|
+  lane :upload_core_sdk_podspec do |options|
     version = options[:version]
     branch_name = "ios-sdk/#{version}"
 
@@ -15,6 +15,23 @@ platform :ios do
       head: branch_name,
       base: "master",
       reviewers: [:gersonnoboa, :dukhovnyi, :igorkravchenko, :EgorovEI]
+    )
+  end
+
+  desc "Creates a PR with the podspec for the Widgets SDK.\n\n"\
+    "Usage:\n"\
+    "fastlane ios upload_widgets_sdk_podspec version:1.0.0\n"
+  lane :upload_widgets_sdk_podspec do |options|
+    version = options[:version]
+    branch_name = "ios-sdk-widgets/#{version}"
+
+    sh "scripts/create_widgets_sdk_pr.sh '#{version}' #{branch_name}"
+    create_pull_request(
+      repo: "salemove/glia-ios-podspecs",
+      title: "Add Widgets SDK podspec for version #{version}",
+      head: branch_name,
+      base: "master",
+      team_reviewers: ["tm-mobile-ios"]
     )
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,16 +15,28 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## iOS
 
-### ios upload_podspec
+### ios upload_core_sdk_podspec
 
 ```sh
-[bundle exec] fastlane ios upload_podspec
+[bundle exec] fastlane ios upload_core_sdk_podspec
 ```
 
 Creates a PR with the podspec for the Core SDK.
 
 Usage:
 fastlane ios upload_core_sdk_podspec version:1.0.0
+
+
+### ios upload_widgets_sdk_podspec
+
+```sh
+[bundle exec] fastlane ios upload_widgets_sdk_podspec
+```
+
+Creates a PR with the podspec for the Widgets SDK.
+
+Usage:
+fastlane ios upload_widgets_sdk_podspec version:1.0.0
 
 
 ----

--- a/fastlane/bitrise.yml
+++ b/fastlane/bitrise.yml
@@ -10,7 +10,7 @@ workflows:
     - fastlane@3:
         inputs:
         - work_dir: $BITRISE_SOURCE_DIR/fastlane
-        - lane: 'ios upload_podspec version:$BITRISE_GIT_TAG'
+        - lane: 'ios upload_core_sdk_podspec version:$BITRISE_GIT_TAG'
         is_always_run: true
 meta:
   bitrise.io:

--- a/fastlane/scripts/create_core_sdk_pr.sh
+++ b/fastlane/scripts/create_core_sdk_pr.sh
@@ -1,11 +1,16 @@
 SEMVER=$1
 BRANCH_NAME=$2
 
+# Create podspec for new Core SDK release
 git checkout -b "$BRANCH_NAME"
 mkdir ../SalemoveSDK/$SEMVER
 cp -f templates/SalemoveSDK.podspec ../SalemoveSDK/$SEMVER/SalemoveSDK.podspec
 sed -i '' "s/\${CORE_SDK_VERSION_SEMVER}/$SEMVER/" "../SalemoveSDK/$SEMVER/SalemoveSDK.podspec"
 
+# Update Widgets SDK template with new Core SDK version
+sed -i '' "s/.*SalemoveSDK.*/  s.dependency 'SalemoveSDK', '$SEMVER'/" "templates/GliaWidgets.podspec"
+
+# Create commit and push to origin
 git add -A
 git commit -m "Add Core SDK podspec for version $SEMVER"
 git push origin "$BRANCH_NAME":"$BRANCH_NAME"

--- a/fastlane/scripts/create_widgets_sdk_pr.sh
+++ b/fastlane/scripts/create_widgets_sdk_pr.sh
@@ -1,0 +1,13 @@
+SEMVER=$1
+BRANCH_NAME=$2
+
+# Create podspec for new Widgets SDK release
+git checkout -b "$BRANCH_NAME"
+mkdir ../GliaWidgets/$SEMVER
+cp -f templates/GliaWidgets.podspec ../GliaWidgets/$SEMVER/GliaWidgets.podspec
+sed -i '' "s/\${WIDGETS_SDK_VERSION_SEMVER}/$SEMVER/" "../GliaWidgets/$SEMVER/GliaWidgets.podspec"
+
+# Create commit and push to origin
+git add -A
+git commit -m "Add Widgets SDK podspec for version $SEMVER"
+git push origin "$BRANCH_NAME":"$BRANCH_NAME"

--- a/fastlane/templates/GliaWidgets.podspec
+++ b/fastlane/templates/GliaWidgets.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name                  = 'GliaWidgets'
+  s.version               = '${WIDGETS_SDK_VERSION_SEMVER}'
+  s.summary               = 'The Glia iOS Widgets library'
+  s.description           = 'The Glia Widgets library allows to integrate easily a UI/UX for Glia\'s Digital Customer Service platform'
+  s.homepage              = 'https://github.com/salemove/ios-sdk-widgets'
+  s.license               = { :type => 'MIT', :file => 'LICENSE' }
+  s.author                = { 'Glia' => 'support@glia.com' }
+  s.source                = { :git => 'https://github.com/salemove/ios-sdk-widgets.git', :tag => s.version.to_s }
+
+  s.module_name           = 'GliaWidgets'
+  s.ios.deployment_target = '12.0'
+  s.source_files          = 'GliaWidgets/**/*.swift'
+  s.swift_version         = '5.3'
+
+  s.resources             = ['GliaWidgets/Resources/*.{xcassets}', 'GliaWidgets/Resources/**/*.{strings}', 'GliaWidgets/Resources/Font/*.{ttf}']
+  s.resource_bundle       = {
+    'GliaWidgets' => ['GliaWidgets/Resources/*.{xcassets}', 'GliaWidgets/Resources/**/*.{strings}', 'GliaWidgets/Resources/Font/*.{ttf}']
+  }
+  s.exclude_files         = ['GliaWidgets/Window/**']
+
+  s.dependency 'SalemoveSDK', '0.34.3'
+  s.dependency 'PureLayout', '~>3.1'
+  s.dependency 'lottie-ios', '3.2.3'
+end


### PR DESCRIPTION
Generate a new podspec for the Widgets SDK through Fastlane. A new
script has been added. which generates a new branch, generates the
podspec with the version number, creates a branch with the file, and
then Fastlane uses that to create a pull request in this repository.
Also, the creation of the Core SDK has been changed so that whenever
the Core SDK podspec is created, the Widgets SDK podspec template is
changed to reflect the new version too.

MOB-1511