### PR TITLE
Update `bitrise.yml` with web contents

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,8 +10,15 @@ workflows:
     - fastlane@3:
         inputs:
         - work_dir: $BITRISE_SOURCE_DIR/fastlane
-        - lane: 'ios upload_core_sdk_podspec version:$BITRISE_GIT_TAG'
-        is_always_run: true
+        - lane: 'ios upload_core_sdk_podspec version:$NEW_VERSION'
+  upload_widgets_sdk_podspec:
+    steps:
+    - activate-ssh-key@4: {}
+    - git-clone@6: {}
+    - fastlane@3:
+        inputs:
+        - work_dir: $BITRISE_SOURCE_DIR/fastlane
+        - lane: 'ios upload_widgets_sdk_podspec version:$NEW_VERSION'
 meta:
   bitrise.io:
     stack: osx-xcode-13.4.x


### PR DESCRIPTION
Last time I did this, I forgot to then go to Bitrise and activate the option to start having the `yml` file only on the repository, so now I need to do it again. The latest change is that now there is a workflow to add a podspec to the widgets too.

Sorry about the confusion.

MOB-1517