### PR TITLE
Assign codeowners to tm-mobile-ios

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-mobile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @salemove/tm-mobile
+* @salemove/tm-mobile-ios


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns tm-mobile as codeowners.